### PR TITLE
Ensure OpenAI SDK compatible with file citations

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,15 @@ try:
         max_retries=2
     )
     app.logger.info("OpenAI client initialized successfully.")
+
+    from packaging import version
+    min_version = version.parse("1.3.0")
+    installed_version = version.parse(openai.__version__)
+    if installed_version < min_version:
+        raise RuntimeError(
+            f"OpenAI SDK version {min_version} or newer required; found {openai.__version__}"
+        )
+    app.logger.info(f"OpenAI SDK version {openai.__version__} meets minimum requirement")
 except Exception as e:
     app.logger.critical(f"Failed to initialize OpenAI client: {e}", exc_info=True)
     raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=2.0.0,<3.1.0 # O la versión específica que estés usando
 gunicorn>=20.0.0,<23.0.0
-openai>=1.2.0 # O la versión específica que estés usando
+openai>=1.3.0 # O la versión específica que estés usando
 python-dotenv>=0.19.0 # Para desarrollo local, no daña en producción
 httpx>=0.27.0 # Descomentar si es una dependencia directa de tu código o de openai
 openai-agents # Descomentar si lo estás usando explícitamente


### PR DESCRIPTION
## Summary
- bump openai requirement to 1.3+
- add runtime version check for the OpenAI SDK so the server fails early if an older library is installed

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68411b1ce700832e9cfee3d7f5d813f9