### PR TITLE
Enable Cloud Build logging

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -50,11 +50,9 @@ steps:
 timeout: '1600s'
 
 # --- SECCIÓN CORREGIDA: OPCIONES DE LOGGING ---
-# Se ha cambiado a 'NONE' como solución alternativa al error de permisos.
-# Esto evita que Cloud Build intente escribir en Cloud Logging. Los logs del
-# build seguirán siendo visibles en la consola de Cloud Build.
-# La solución ideal a largo plazo es otorgar el rol 'Logs Writer' 
-# a la cuenta de servicio: 
-# 'cloud-build-dev-executor@recava-auditor-dev.iam.gserviceaccount.com'.
+# Se restablece el envío de logs a Cloud Logging. Es necesario otorgar el
+# rol 'Logs Writer' a la cuenta de servicio
+# 'cloud-build-dev-executor@recava-auditor-dev.iam.gserviceaccount.com'
+# para que Cloud Build pueda escribir en Cloud Logging.
 options:
-  logging: NONE
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- restore cloudbuild logging to send output to Cloud Logging

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a3ded0364832e855166691623a046